### PR TITLE
Relax the `no-confusing-arrow` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ module.exports = {
 		"no-bitwise": "off",
 		"no-buffer-constructor": "error",
 		"no-caller": "error",
-		"no-confusing-arrow": "error",
+		"no-confusing-arrow": ["error", {"allowParens": true}],
 		"no-constant-condition": [
 			"error",
 			{


### PR DESCRIPTION
Could we please relax the `no-confusing-arrow` eslint rule?

While it never occurred to me before, I understand that `=>` might be confused with `>=` etc. as per [example](https://eslint.org/docs/rules/no-confusing-arrow). However I think adding parentheses should be enough clear such confusion.

Combining arrow functions with ternary logic is a common and legible pattern, especially useful when mapping an array etc.