### PR TITLE
Make config more forgiving of common patterns

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,7 +298,7 @@ module.exports = {
 		"prefer-template": "off",
 		"quote-props": [
 			"error",
-			"consistent"
+			"as-needed"
 		],
 		"quotes": "off",
 		"radix": [

--- a/index.js
+++ b/index.js
@@ -39,7 +39,12 @@ module.exports = {
 			"stroustrup"
 		],
 		"callback-return": "off",
-		"camelcase": "error",
+		"camelcase": [
+			"error",
+			{
+				"allow": ["^Zotero_", "^ZoteroPane_Local$"]
+			}
+		],
 		"capitalized-comments": "off",
 		"comma-dangle": "off",
 		"comma-spacing": [
@@ -66,7 +71,12 @@ module.exports = {
 			"error",
 			"property"
 		],
-		"dot-notation": "error",
+		"dot-notation": [
+			"error",
+			{
+				"allowPattern": "^[A-Z]"
+			}
+		],
 		"eol-last": "error",
 		"eqeqeq": "off",
 		"func-call-spacing": "error",
@@ -288,7 +298,7 @@ module.exports = {
 		"prefer-template": "off",
 		"quote-props": [
 			"error",
-			"as-needed"
+			"consistent"
 		],
 		"quotes": "off",
 		"radix": [


### PR DESCRIPTION
- No more error when accessing `Zotero_*`-named objects or `ZoteroPane_Local`
- Allow `object["Property"]` instead of `object.Property` when the first letter of the property name is uppercase - looks confusingly like a class, ugly, common issue when dealing with HTTP headers
- Enforce quote consistency within object literals
	- OK: `{ "foo": 1, "bar": 2 }`
	- OK: `{ foo: 1, bar: 2 }`
	- Not OK: `{ foo: 1, "bar": 2 }`
	- Again, useful when dealing with HTTP headers and such. There's no option to set an allowed pattern for this rule, so the best we can do is enforce consistency