### PR TITLE
Don't complain about multiline comments in blocks, standardize quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,19 @@ module.exports = {
 			"error",
 			"unix"
 		],
-		"lines-around-comment": "error",
+		"lines-around-comment": [
+			"error",
+			{
+				"allowBlockStart": true,
+				"allowBlockEnd": true,
+				"allowObjectStart": true,
+				"allowObjectEnd": true,
+				"allowArrayStart": true,
+				"allowArrayEnd": true,
+				"allowClassStart": true,
+				"allowClassEnd": true
+			}
+		],
 		"lines-between-class-members": "error",
 		"max-depth": "off",
 		"max-len": "off",

--- a/index.js
+++ b/index.js
@@ -312,7 +312,14 @@ module.exports = {
 			"error",
 			"as-needed"
 		],
-		"quotes": "off",
+		"quotes": [
+			"error",
+			"single",
+			{
+				"avoidEscape": true,
+				"allowTemplateLiterals": true
+			}
+		],
 		"radix": [
 			"error",
 			"as-needed"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zotero/eslint-config",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"description": "ESLint config for Zotero",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
- This would've caused an error before:

	```js
	class Foo {
		/** Doc comment */
		doFoo() {}
	}
	```

    Happens all over the place in zotero/zotero.

- Our quote styles have become very inconsistent - a lot of older code uses double quotes, newer-ish code uses single quotes, and some recent code (especially CE code) uses both. This sets the quote style to single everywhere and enforces it as an ESLint error. Maybe controversial but I think it's for the greater good!

    We'd want to follow this up with a cleanup commit in zotero/zotero (ESLint can do that automatically), which we could [add](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) to `.git-blame-ignore-revs` so blames stay clean.

    If a file (e.g. a direct port of Mozilla code) needs to consistently use double quotes instead, it can have an `/* eslint quotes: ["error", "double"] */` comment at the top.